### PR TITLE
Add Singapore mobile number verification

### DIFF
--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -1,3 +1,8 @@
 export const OTP_REQUEST_TIMEOUT = 60000; // ms = 1 min
 export const RECAPTCHA_CONTAINER_ID = "recaptcha-container";
 export const RECAPTCHA_CONTAINER_ELEMENT = `<div id="${RECAPTCHA_CONTAINER_ID}"></div>`;
+export const REGEX_E164_NUMBER = /^\+[1-9]\d{1,14}$/;
+export const REGEX_MOBILE_SG = /^(8|9)\d{7}$/;
+export const COUNTRY_CODE_SG = "65";
+export const AUTH_ERROR_INVALID_PHONE =
+  "Please enter an 8-digit Singapore mobile number or number with country code.";

--- a/src/features/auth/get_otp/GetOTPButton.tsx
+++ b/src/features/auth/get_otp/GetOTPButton.tsx
@@ -4,20 +4,29 @@ import { selectNumber } from "../loginSlice";
 import useFirebaseGetOTP, {
   useFirebaseGetOTPProps,
 } from "../../../hooks/useFirebaseGetOTP";
+import verifyPhoneNumber from "./verifyPhoneNumber";
+import { AUTH_ERROR_INVALID_PHONE } from "../../../constants";
 
-const GetOTPButton: React.FC<useFirebaseGetOTPProps> = function (
-  props: useFirebaseGetOTPProps
+interface GetOTPButtonProps extends useFirebaseGetOTPProps {
+  setError: React.Dispatch<React.SetStateAction<string | undefined>>;
+}
+
+const GetOTPButton: React.FC<GetOTPButtonProps> = function (
+  props: GetOTPButtonProps
 ) {
   const inputNumber = useAppSelector(selectNumber);
   const getOTPFromFirebase = useFirebaseGetOTP({ ...props });
-
+  const { setError } = props;
   /**
    * Request for OTP through firebase authentication.
    * @param ev The DOM event triggerred by a mouse click.
    */
   const handleGetOTP = async (ev: React.MouseEvent<HTMLButtonElement>) => {
     ev.preventDefault();
-    getOTPFromFirebase(inputNumber);
+    const phoneNumber = verifyPhoneNumber(inputNumber);
+    if (!phoneNumber) return setError(AUTH_ERROR_INVALID_PHONE);
+    setError(undefined);
+    getOTPFromFirebase(phoneNumber);
   };
 
   return (

--- a/src/features/auth/get_otp/GetOTPForm.tsx
+++ b/src/features/auth/get_otp/GetOTPForm.tsx
@@ -1,14 +1,16 @@
-import React from "react";
+import React, { useState } from "react";
 import FormField from "../../../components/form/FormField";
 import { useAppDispatch } from "../../../hooks";
 import { useFirebaseGetOTPProps } from "../../../hooks/useFirebaseGetOTP";
 import GetOTPButton from "./GetOTPButton";
 import { onChangeNumber } from "../loginSlice";
+import PopupMessage from "../../../components/PopupMessage";
 
 const GetOTPForm: React.FC<useFirebaseGetOTPProps> = function (
   props: useFirebaseGetOTPProps
 ) {
   const dispatch = useAppDispatch();
+  const [error, setError] = useState<string>();
 
   // Handle form input change
   /**
@@ -23,6 +25,7 @@ const GetOTPForm: React.FC<useFirebaseGetOTPProps> = function (
 
   return (
     <form className="login-form__phone">
+      {error && <PopupMessage status="error" message={error} />}
       <div className="form-field">
         <FormField
           labelContent="Phone Number"
@@ -30,7 +33,7 @@ const GetOTPForm: React.FC<useFirebaseGetOTPProps> = function (
           disabled={false}
         />
       </div>
-      <GetOTPButton {...props} />
+      <GetOTPButton {...props} setError={setError} />
     </form>
   );
 };

--- a/src/features/auth/get_otp/verifyPhoneNumber.ts
+++ b/src/features/auth/get_otp/verifyPhoneNumber.ts
@@ -1,0 +1,13 @@
+import {
+  COUNTRY_CODE_SG,
+  REGEX_E164_NUMBER,
+  REGEX_MOBILE_SG,
+} from "../../../constants";
+
+export default function (phone: string): string | undefined {
+  // phone number is from Singapore
+  if (phone.match(REGEX_MOBILE_SG)) return `+${COUNTRY_CODE_SG}${phone}`;
+  // valid E164 number (+<country code><number>)
+  if (phone.match(REGEX_E164_NUMBER)) return phone;
+  return undefined;
+}


### PR DESCRIPTION
Improved UX. Allow users to input 8-digit mobile numbers starting with 8 or 9 or valid E164 numbers (starting with '+' up to 14 digits)